### PR TITLE
ignore extra_roles diretory

### DIFF
--- a/lib/qansible/commands/init/templates/rubocop.yml
+++ b/lib/qansible/commands/init/templates/rubocop.yml
@@ -6,6 +6,7 @@ AllCops:
     - "roles.galaxy/**/*"
     - "vendor/**/*"
     - "tests/integration/**/roles/*"
+    - "extra_roles"
     - "qansible"
   # enable detailed explanations available in cops
   # the default output is not enough to understand what is wrong

--- a/lib/qansible/commands/init/templates/rubocop.yml
+++ b/lib/qansible/commands/init/templates/rubocop.yml
@@ -6,7 +6,7 @@ AllCops:
     - "roles.galaxy/**/*"
     - "vendor/**/*"
     - "tests/integration/**/roles/*"
-    - "extra_roles"
+    - "extra_roles/**/*"
     - "qansible"
   # enable detailed explanations available in cops
   # the default output is not enough to understand what is wrong


### PR DESCRIPTION
the directory shows up only in Travis CI environment, where depended roles are downloaded. these roles are external code and should be excluded in `.rubocop.yml`.