### PR TITLE
do not warn when `block` does not have `name` 

### DIFF
--- a/lib/qansible/checks/tasks.rb
+++ b/lib/qansible/checks/tasks.rb
@@ -34,6 +34,7 @@ module Qansible
       def should_have_tasks_with_name
         exceptions = %w[
           assert
+          block
           debug
           fail
           include


### PR DESCRIPTION
fixes #55